### PR TITLE
Refactor memoization into stand-alone class

### DIFF
--- a/lib/appear/join.rb
+++ b/lib/appear/join.rb
@@ -57,7 +57,7 @@ module Appear
     # Access the given field on an object.
     # Raises an error if the field cannot be accessed.
     #
-    # @param object [Any]
+    # @param obj [Any]
     # @param field [Symbol, String]
     # @return [Any] the value at that field
     def self.access(obj, field)

--- a/lib/appear/memoizer.rb
+++ b/lib/appear/memoizer.rb
@@ -1,0 +1,34 @@
+require 'thread'
+module Appear
+  # A Memoizer memoizes calls to a block, skipping repeated work when the
+  # arguments are the same.
+  class Memoizer
+    def initialize
+      @cache = {}
+      @cache_mutex = Mutex.new
+    end
+
+    # Memoize the call to a block. Any arguments given to this method will be
+    # passed to the given block.
+    def call(*args)
+      raise ArgumentError.new('no block given') unless block_given?
+      @cache_mutex.synchronize do
+        return @cache[args] if @cache.key?(args)
+      end
+
+      result = yield(*args)
+      @cache_mutex.synchronize do
+        @cache[args] = result
+      end
+      result
+    end
+
+    # Evict the cache
+    def clear!
+      @cache_mutex.synchronize do
+        @cache = {}
+      end
+      nil
+    end
+  end
+end

--- a/lib/appear/processes.rb
+++ b/lib/appear/processes.rb
@@ -24,7 +24,7 @@ module Appear
 
     def initialize(*args)
       super(*args)
-      @cache = {}
+      @get_info_memo = Memoizer.new
     end
 
     # Get info about a process by PID, including its command and parent_pid.
@@ -32,12 +32,9 @@ module Appear
     # @param pid [Integer]
     # @return [ProcessInfo]
     def get_info(pid)
-      result = @cache[pid]
-      unless result
-        result = fetch_info(pid)
-        @cache[pid] = result
+      @get_info_memo.call(pid) do
+        fetch_info(pid)
       end
-      result
     end
 
     # Is the given process alive?

--- a/spec/memoizer_spec.rb
+++ b/spec/memoizer_spec.rb
@@ -1,0 +1,39 @@
+require 'appear/memoizer'
+RSpec.describe Appear::Memoizer do
+  describe '#call' do
+    it 'memoizes calls with the same arguments' do
+      value = 0
+      arg = 'foo'
+      2.times do
+        subject.call(arg) do
+          value += 1
+        end
+      end
+
+      expect(value).to eq(1)
+    end
+
+    it 'returns the result from first call with that argument' do
+      did_call = false
+      subject.call() do
+        next "second call" if did_call
+        did_call = true
+        next "first call"
+      end
+      expect(subject.call() {}).to eq("first call")
+    end
+
+    it 'returns different results for different params' do
+      a = subject.call('a') { 1 }
+      b = subject.call('b') { 2 }
+      expect(a).to eq(1)
+      expect(b).to eq(2)
+    end
+
+    it 'raises if no block given' do
+      expect do
+        subject.call()
+      end.to raise_error(ArgumentError, /no block given/)
+    end
+  end
+end

--- a/spec/processes_spec.rb
+++ b/spec/processes_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe(Appear::Processes) do
   end
 
   def kill_cat
-    i, o, info = cat
+    *, info = cat
     begin
       Process.kill(9, info.pid)
       # wait for exactly cat_info.pid

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,7 +79,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
- introduce `Memoizer` class, which is a thread-safe memoization helper.
- refactor the cache in the `Lsof` service to greatly simplify how parallel lsofs works. Now uses `Memoizer` class.
- refactor the cache in the `Processes` service to use the `Memoizer` class.
