### PR TITLE
Add Appear.build_command, for use with terminal-notifier

### DIFF
--- a/lib/appear/output.rb
+++ b/lib/appear/output.rb
@@ -10,6 +10,9 @@ module Appear
     # @param log_file_name [String, nil] if a string, log to the file at this path
     # @param silent [Boolean] if true, output to STDERR
     def initialize(log_file_name, silent)
+      @file_logger = nil
+      @stderr_logger = nil
+
       @file_logger = Logger.new(log_file_name.to_s) if log_file_name
       @stderr_logger = Logger.new(STDERR) unless silent
     end

--- a/spec/appear_spec.rb
+++ b/spec/appear_spec.rb
@@ -1,0 +1,41 @@
+require 'appear'
+RSpec.describe Appear do
+  subject do
+    Appear
+  end
+
+  let :instance do
+    Appear::Instance.new(Appear::Config.new)
+  end
+
+  describe '.appear' do
+    it 'can appear' do
+      expect(Appear::Instance).to receive(:new).and_return(instance)
+      expect(instance).to receive(:call).with(1)
+
+      subject.appear(1)
+    end
+
+    it 'can appear with config' do
+      config = Appear::Config.new
+
+      expect(Appear::Instance).to receive(:new).with(config).and_return(instance)
+      expect(instance).to receive(:call).with(1)
+
+      subject.appear(1, config)
+    end
+  end
+
+  describe '.build_command' do
+    it 'builds a command string' do
+      expect(subject.build_command(1)).to match(/appear 1$/)
+    end
+
+    it 'builds with options if config provided' do
+      config = Appear::Config.new
+      config.silent = false
+      config.log_file = 'foo'
+      expect(subject.build_command(1, config)).to match(/appear 1 --verbose --log-file foo$/)
+    end
+  end
+end


### PR DESCRIPTION
- Appear.build_command builds a command string that will execute
  `appear`. This is useful for passing to the terminal-notifier gem so
  it can reveal your program.
- spec for everything on the Appear module
