### PR TITLE
FreeBSD compatability

### DIFF
--- a/lib/appear/instance.rb
+++ b/lib/appear/instance.rb
@@ -44,6 +44,11 @@ module Appear
     def call(pid)
       tree = process_tree(pid)
 
+      log "Process tree:"
+      tree.each do |info|
+        log "  #{info}"
+      end
+
       statuses = ::Appear::REVEALERS.map do |klass|
         revealer = klass.new(@all_services)
         revealer.call(tree)

--- a/lib/appear/processes.rb
+++ b/lib/appear/processes.rb
@@ -55,9 +55,15 @@ module Appear
     # @return [Array<ProcessInfo>]
     def process_tree(pid)
       tree = [ get_info(pid) ]
-      while tree.last.pid > 1 && tree.last.parent_pid != 0
-        tree << get_info(tree.last.parent_pid)
+
+      begin
+        while tree.last.pid > 1 && tree.last.parent_pid != 0
+          tree << get_info(tree.last.parent_pid)
+        end
+      rescue DeadProcess
+        # that's ok
       end
+
       tree
     end
 

--- a/lib/appear/processes.rb
+++ b/lib/appear/processes.rb
@@ -86,10 +86,10 @@ module Appear
 
     def fetch_info(pid)
       raise DeadProcess.new("cannot fetch info for dead PID #{pid}") unless alive?(pid)
-      output = run(['ps', '-p', pid.to_s, '-o', 'ppid=', '-o', 'command='])
-      ppid, *command = output.strip.split(/\s+/).reject(&:empty?)
-      name = File.basename(command.first)
-      ProcessInfo.new({:pid => pid.to_i, :parent_pid => ppid.to_i, :command => command, :name => name})
+      output = run(['ps', '-p', pid.to_s, '-o', 'ppid=', '-o', 'comm=', '-o', 'args='])
+      ppid, command, *args = output.strip.split(/\s+/).reject(&:empty?)
+      name = File.basename(command)
+      ProcessInfo.new({:pid => pid.to_i, :parent_pid => ppid.to_i, :command => args, :name => name})
     end
   end
 end

--- a/lib/appear/processes.rb
+++ b/lib/appear/processes.rb
@@ -20,6 +20,10 @@ module Appear
           send("#{key}=", value)
         end
       end
+
+      def to_s
+        'ProcessInfo' + {pid: pid, command: command, name: name, parent_pid: parent_pid}.inspect
+      end
     end
 
     def initialize(*args)

--- a/lib/appear/revealers.rb
+++ b/lib/appear/revealers.rb
@@ -19,7 +19,10 @@ module Appear
       def call(tree)
         target, *rest = tree
         if supports_tree?(target, rest)
+          log("#{self.class.name}: running")
           return reveal_tree(tree)
+        else
+          log("#{self.class.name}: no support")
         end
       end
 


### PR DESCRIPTION
This branch adds basic support for FreeBSD, which is different enough from Linux/macOS that customizations were required. The branch is developed on a FreeBSD 10 server, in a jail. The only supported revealer on FreeBSD is the tmux revealer.

Currently, this branch can reveal a tmux pane, but then crashes afterwards in the `#tmux_client_for_tree` method. Appear dies trying to run `lsof` against a non-existent /dev/pts/1, which is the TTY that tmux reports its client is attached to. This is rather odd -- maybe it has something to do with jails?
